### PR TITLE
Species filter control

### DIFF
--- a/overrides.coffee
+++ b/overrides.coffee
@@ -5,6 +5,9 @@ SubjectMetadata = require './subject-metadata'
 SubjectViewer = require 'zooniverse-readymade/lib/subject-viewer'
 ClassifyPage = require 'zooniverse-readymade/lib/classify-page'
 SiteHeader = require 'zooniverse-readymade/lib/site-header'
+
+OrchidFilterTask = require './tasks/filter'
+DecisionTree = require 'zooniverse-decision-tree'
   
 ClassifyPage::showPageHelp = () ->
   @fieldGuideContainer.attr 'aria-hidden', !@help.checked
@@ -76,10 +79,6 @@ for page in currentProject.classifyPages
           
         # disable the herbarium species if NHM already know it.
         herbarium_species.disabled = !!metadata.species.length
-      
-      if page.workflow is 'field'
-        page.decisionTree.tasks.species.setDefaults
-          species: metadata.species
       
 
 subject_metadata = new SubjectMetadata

--- a/project.styl
+++ b/project.styl
@@ -88,15 +88,25 @@
     
     .decision-tree-task
     
-      &[data-task-type=filter]
+      .readymade-filter-menu
+        background: white
+        max-width: 10em
+    
+      &[data-task-type=accessible-filter]
       
         .decision-tree-choice
           display: inline-block
-          width: 30%
+          width: 15%
           
-          label
-            display: inline
+          .readymade-choice-label
             font-size: .6em
+          
+          input:checked + .readymade-choice-clickable
+            background: #000
+            font-weight: bold
+      
+        [aria-hidden=true]
+          display: none
   
   .readymade-field-guide-container
     position: absolute
@@ -225,7 +235,7 @@
     top: 6em
     flex: 1
     min-width: 15%
-    max-width: 200px
+    max-width: 300px
     z-index: 5
   
   .drawing-controls

--- a/tasks/filter.coffee
+++ b/tasks/filter.coffee
@@ -1,0 +1,94 @@
+DecisionTree = require 'zooniverse-decision-tree'
+RadioTask = require 'zooniverse-readymade/lib/tasks/radio'
+
+class OrchidFilterTask extends RadioTask
+  @type: 'accessible-filter'
+  
+  choiceTemplate: require '../templates/filter-choice'
+
+  filters: null
+
+  currentFilters: null
+
+  buttons: null
+  menus: null
+  clearButtons: null
+  dropdowns: null
+
+  filtersTemplate: -> "
+    <div class='readymade-classification-filters'>
+      #{("
+        <div class='readymade-classification-filter'>
+          <label for='#{filter.key}-filter' class='readymade-filter-button'>#{filter.label}</label>
+
+          <select id=#{filter.key}-filter class='readymade-filter-menu'>
+              <option value=''>Any</option>
+              #{("<option value=#{option.value}>#{option.label}</option>" for option, o in filter.values).join '\n'}
+          </select>
+        </div>
+      " for filter, i in @filters).join '\n'}
+    </div>
+  "
+
+  constructor: ->
+    super
+    @currentFilters ?= {}
+    @reflectFilter()
+
+  renderTemplate: ->
+    super
+    questionEl = @el.querySelector '.decision-tree-question'
+    questionEl.insertAdjacentHTML 'afterEnd', @filtersTemplate()
+
+    filtersEl = @el.querySelector '.readymade-classification-filters'
+
+    @buttons = Array::slice.call filtersEl.querySelectorAll '.readymade-filter-button'
+    @menus = Array::slice.call filtersEl.querySelectorAll '.readymade-filter-menu'
+    
+  getChoice: ->
+    checkedInput = @el.querySelector 'input[type=radio]:checked'
+    choiceIndex = checkedInput?.getAttribute 'data-choice-index'
+    @choices[choiceIndex]
+
+  enter: ->
+    super
+    for i in [0...@menus.length]
+      @menus[i].addEventListener 'change', this
+
+  exit: ->
+    for i in [0...@menus.length]
+      @menus[i].removeEventListener 'change', this
+    super
+
+  handleEvent: (e) ->
+    if e.type is 'change' and e.currentTarget in @menus
+      @handleFilterChange @menus.indexOf e.currentTarget
+    else
+      super
+
+  handleFilterChange: (index) ->
+    value = @menus[index].value
+    if value
+      @currentFilters[@filters[index].key] = value
+    else
+      @clearFilter index
+
+    @reflectFilter @currentFilters
+
+  clearFilter: (index) ->
+    @menus[index].value = ''
+    delete @currentFilters[@filters[index].key]
+    @reflectFilter @currentFilters
+
+  reflectFilter: (filterSettings) ->
+    choiceEls = @el.querySelectorAll '.decision-tree-choice'
+    for choice, i in choiceEls
+      choice.removeAttribute 'aria-hidden'
+      for key, value of filterSettings
+        unless value in @choices[i].traits[key]
+          choice.setAttribute 'aria-hidden', true
+
+DecisionTree.registerTask OrchidFilterTask
+
+DecisionTree.FilterTask = OrchidFilterTask
+module.exports = OrchidFilterTask

--- a/templates/filter-choice.coffee
+++ b/templates/filter-choice.coffee
@@ -1,0 +1,21 @@
+# This is not a proper eco template at the moment because it takes arguments.
+
+module.exports = (choice, i) -> "
+  <label class='readymade-choice-input-wrapper'>
+    <input type='radio'
+      name='#{@key}'
+      value='#{choice.value}'
+      #{if choice.checked then 'checked="checked"' else ''}
+      data-choice-index='#{i}'
+    />
+
+    <span class='readymade-choice-clickable readymade-choice-#{@constructor.type ? @type}'>
+
+      #{if choice.image? then "<span class='readymade-choice-image'><img src='#{choice.image}' /></span>" else ''}
+
+      <span class='readymade-choice-label'>#{choice.label ? choice.value ? i}</span>
+
+      #{if choice.color? then "<span class='readymade-choice-color' style='color: #{choice.color};'></span>" else ''}
+    </span>
+  </label>
+"

--- a/workflows/field.coffee
+++ b/workflows/field.coffee
@@ -3,6 +3,7 @@ Pinpoint = require '../drawing-tools/pinpoint'
 FreeDraw = require '../drawing-tools/free-draw-tool'
 TextTask = require '../tasks/text'
 TextareaTask = require '../tasks/textarea'
+OrchidFilterTask = require '../tasks/filter'
 
 module.exports =
   key: 'field'
@@ -13,7 +14,7 @@ module.exports =
   tutorialSteps: require '../content/tutorial-steps'
   tasks: 
     species:
-      type: 'filter'
+      type: OrchidFilterTask.type
       question: 'Verify the species'
       confirmButtonLabel: 'Finish'
       filters: [{


### PR DESCRIPTION
First steps towards an accessible, more usable filter control.
Avoids using zoo dropdowns.
Add an 'accessible-filter' task type.
New choice template.
Inline styling for choices
Update getChoice to ignore select menus.
Embiggen the task choices panel.
Use aria-hidden instead of data-filtered.
