### PR TITLE
Herbarium tasks

### DIFF
--- a/drawing-tools/magnifier-point.coffee
+++ b/drawing-tools/magnifier-point.coffee
@@ -1,0 +1,14 @@
+MagnifierPoint = require 'marking-surface/lib/tools/magnifier-point'
+
+class SingleMagnifierPoint extends MagnifierPoint
+  @count = 0
+  
+  constructor: ->
+    super
+    SingleMagnifierPoint.count++
+  
+  destroy: =>
+    super
+    SingleMagnifierPoint.count--
+    
+module.exports = SingleMagnifierPoint

--- a/drawing-tools/rectangle.coffee
+++ b/drawing-tools/rectangle.coffee
@@ -3,6 +3,15 @@ ToolControls = require './tool-controls'
 
 class Rectangle extends RectangleTool
   @Controls: ToolControls
+  @count = 0
+  
+  constructor: ->
+    super
+    Rectangle.count++
+  
+  destroy: =>
+    super
+    Rectangle.count--
   
   coords: (e) ->
     @markingSurface.screenPixelToScale @markingSurface.svg.pointerOffset e

--- a/project.styl
+++ b/project.styl
@@ -179,12 +179,11 @@
   
   .readymade-marking-surface-container
     .drawing-controls
-      position: absolute
-      top: 0
-      right: 10em
+      position: fixed
+      top: 6em
+      right: 30em
   
   .drawing-controls
-  .readymade-marking-surface-container
     
     .readymade-clickable
       display: block

--- a/readymade/marking-surface.coffee
+++ b/readymade/marking-surface.coffee
@@ -1,8 +1,9 @@
 MarkingSurface = require 'marking-surface'
 
 MarkingSurface.prototype.rescale = (x, y, width, height) ->
-  root = @root.el.getBoundingClientRect()
-  return if root.width is 0 # don't rescale when surface isn't visible
+  image = @root.el.querySelector 'g.frames image'
+  image = image.getBoundingClientRect()
+  return unless image.width # don't rescale when surface isn't visible
   return unless @maxWidth? # don't rescale until image has been loaded
   currentViewBox = @svg.attr('viewBox')?.split /\s+/
   x ?= parseInt currentViewBox?[0] ? 0
@@ -11,9 +12,8 @@ MarkingSurface.prototype.rescale = (x, y, width, height) ->
   height ?= parseInt currentViewBox?[3] ? @maxHeight
   @svg.attr 'viewBox', [x, y, width, height].join ' '
   
-  root = @root.el.getBoundingClientRect()
-  @scaleX = root.width / @maxWidth
-  @scaleY = root.height / @maxHeight
+  @scaleX = image.width / @maxWidth
+  @scaleY = image.height / @maxHeight
   @magnification = (@scaleX + @scaleY) / 2
   
   # recalculate the viewbox so that the aspect ratio matches the SVG element

--- a/workflows/herbarium.coffee
+++ b/workflows/herbarium.coffee
@@ -3,30 +3,35 @@ Pinpoint = require '../drawing-tools/pinpoint'
 FreeDraw = require '../drawing-tools/free-draw-tool'
 TextTask = require '../tasks/text'
 TextareaTask = require '../tasks/textarea'
+MagnifierPoint = require '../drawing-tools/magnifier-point'
 
 module.exports =
   key: 'herbarium'
   label: 'Herbarium'
   subjectGroup: 'herbarium'
-  firstTask: 'flowering'
+  firstTask: 'barcode'
   examples: require '../content/examples'
   tutorialSteps: require '../content/tutorial-steps'
   tasks:
-    marking:
+    barcode:
       type: 'drawing'
-      question: 'Draw a rectangle around the label for this specimen'
+      question: 'Find the barcode for this specimen'
       choices: [{
+        type: MagnifierPoint
+        label: 'Barcode'
+        value: 'barcode'
+        color: '#660066'
+        checked: true
+      },{
         type: Rectangle
         label: 'Specimen label'
-        value: 'rectangle'
+        value: 'specimen-label'
         color: '#006666'
-        checked: true
       }]
       next: 'verify'
     verify:
       type: 'text'
-      question: 'Verify the specimen label'
-      confirmButtonLabel: 'Finish'
+      question: 'Verify the written specimen label'
       defaults: {}
       choices: [{
         label: 'Species'
@@ -41,24 +46,31 @@ module.exports =
         key: 'locality'
         value: ''
       },{
+        label: 'Label comments'
+        key: 'comments'
+        value: ''
+      }]
+      next: 'vc'
+    vc:
+      type: 'text'
+      question: 'There may be a VC number and registration label also on the sheet.'
+      defaults: {}
+      choices: [{
         label: 'Vice-county'
         key: 'vc'
         value: ''
         length: 3
       },{
-        label: 'Label comments'
-        key: 'comments'
-        value: ''
-      },{
         label: 'Registration'
         key: 'registration'
         value: ''
       }]
-      next: null
+      next: 'flowering'
     flowering:
       type: 'drawing'
       question: 'Identify the flowering stage of this specimen.'
       next: 'marking'
+      confirmButtonLabel: 'Finish'
       choices: [{
         type: Pinpoint
         label: 'Flowering stage'


### PR DESCRIPTION
Fixed position magnifier buttons
Split label task into two tasks: label and vice-county.
Add a magnifier point for barcodes.
Rearrange the herbarium task order: barcode > label > vice-county > flowering stage.
Fix close buttons
Change the svg viewbox to crop images.
Use the first svg frame image to calculate the rendered size of the marking surface.
Limit the magnifier point and rectangle tools to one instance each.
